### PR TITLE
fix: align message service manifest schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lasso-totaljs-messageservice
 
-Service Lasso package repo for the TypeRefinery Total.js Message Service donor app.
+Service Lasso package repo for the Total.js Message Service app.
 
 The release pipeline packages the app with production `npm` dependencies already installed, publishes OS-specific archives, and publishes the matching `service.json` manifest.
 

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -84,8 +84,7 @@ export async function packageMessageService(platform = targetPlatform, version =
       {
         serviceId: "totaljs-messageservice",
         upstream: {
-          source: "TypeRefinery donor service",
-          donorPath: "services/totaljs-messageservice",
+          source: "Total.js Message Service",
           version,
         },
         packagedBy: "service-lasso/lasso-totaljs-messageservice",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +10,21 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const serviceVersion = process.env.TOTALJS_MESSAGESERVICE_VERSION ?? "12.0.0";
 const targetPlatform = process.env.TARGET_PLATFORM ?? process.platform;
 const verifyPort = Number(process.env.VERIFY_PORT ?? 18112);
+
+const serviceManifest = JSON.parse(await readFile(path.join(repoRoot, "service.json"), "utf8"));
+if (
+  serviceManifest.id !== "totaljs-messageservice" ||
+  serviceManifest.execservice !== "@node" ||
+  serviceManifest.artifact?.kind !== "archive" ||
+  serviceManifest.artifact.platforms?.[targetPlatform]?.assetName !== archiveName(targetPlatform) ||
+  serviceManifest.artifact.platforms?.[targetPlatform]?.archiveType !== (targetPlatform === "win32" ? "zip" : "tar.gz") ||
+  serviceManifest.ports?.service !== 8112 ||
+  serviceManifest.healthcheck?.type !== "http" ||
+  serviceManifest.healthcheck?.expected_status !== 404 ||
+  !serviceManifest.depend_on?.includes("@node")
+) {
+  throw new Error(`Total.js Message Service manifest drifted from current Service Lasso schema: ${JSON.stringify(serviceManifest)}`);
+}
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {

--- a/service.json
+++ b/service.json
@@ -5,10 +5,28 @@
   "description": "Total.js TMS server packaged for Service Lasso.",
   "version": "12.0.0",
   "enabled": true,
-  "status": "30",
-  "icon": "pi pi-globe",
-  "servicelocation": 10,
+  "execservice": "@node",
+  "ports": {
+    "service": 8112
+  },
+  "env": {
+    "NODE_ENV": "production",
+    "MESSAGESERVICE_PORT": "${SERVICE_PORT}",
+    "MESSAGESERVICE_URL": "http://127.0.0.1:${SERVICE_PORT}"
+  },
+  "globalenv": {
+    "MESSAGESERVICE_URL": "${MESSAGESERVICE_URL}",
+    "MESSAGESERVICE_PORT": "${MESSAGESERVICE_PORT}"
+  },
+  "urls": [
+    {
+      "label": "Total.js Message Service",
+      "url": "${MESSAGESERVICE_URL}/",
+      "kind": "local"
+    }
+  ],
   "artifact": {
+    "kind": "archive",
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-totaljs-messageservice",
@@ -16,60 +34,42 @@
     },
     "platforms": {
       "win32": {
-        "asset": "lasso-totaljs-messageservice-12.0.0-win32.zip",
-        "archive": "zip",
+        "assetName": "lasso-totaljs-messageservice-12.0.0-win32.zip",
+        "archiveType": "zip",
         "command": "./lasso-totaljs-messageservice.mjs"
       },
       "linux": {
-        "asset": "lasso-totaljs-messageservice-12.0.0-linux.tar.gz",
-        "archive": "tar.gz",
+        "assetName": "lasso-totaljs-messageservice-12.0.0-linux.tar.gz",
+        "archiveType": "tar.gz",
         "command": "./lasso-totaljs-messageservice.mjs"
       },
       "darwin": {
-        "asset": "lasso-totaljs-messageservice-12.0.0-darwin.tar.gz",
-        "archive": "tar.gz",
+        "assetName": "lasso-totaljs-messageservice-12.0.0-darwin.tar.gz",
+        "archiveType": "tar.gz",
         "command": "./lasso-totaljs-messageservice.mjs"
       }
     }
   },
-  "execconfig": {
-    "debuglog": true,
-    "execservice": {
-      "id": "@node"
-    },
-    "commandline": {
-      "win32": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
-      "linux": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
-      "darwin": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
-      "default": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs"
-    },
-    "env": {
-      "NODE_ENV": "production",
-      "MESSAGESERVICE_PORT": "${SERVICE_PORT}",
-      "MESSAGESERVICE_URL": "http://127.0.0.1:${SERVICE_PORT}"
-    },
-    "globalenv": {
-      "MESSAGESERVICE_URL": "http://127.0.0.1:${SERVICE_PORT}",
-      "MESSAGESERVICE_PORT": "${SERVICE_PORT}"
-    },
-    "serviceport": 8112,
-    "healthcheck": {
-      "type": "http",
-      "url": "http://127.0.0.1:${SERVICE_PORT}/",
-      "expected_status": 404,
-      "retries": 180,
-      "interval_ms": 500
-    },
-    "depend_on": [
-      "@node"
-    ]
+  "commandline": {
+    "win32": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
+    "linux": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
+    "darwin": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
+    "default": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs"
   },
+  "healthcheck": {
+    "type": "http",
+    "url": "http://127.0.0.1:${SERVICE_PORT}/",
+    "expected_status": 404,
+    "retries": 180,
+    "interval": 500
+  },
+  "depend_on": [
+    "@node"
+  ],
   "updates": {
-    "policy": "notify",
-    "source": {
-      "type": "github-release",
-      "repo": "service-lasso/lasso-totaljs-messageservice",
-      "channel": "latest"
-    }
+    "enabled": true,
+    "mode": "notify",
+    "track": "latest",
+    "checkIntervalSeconds": 86400
   }
 }


### PR DESCRIPTION
Closes #2.

## Change
- Rewrites `service.json` to the current Service Lasso manifest shape with `artifact.kind`, `assetName`, `archiveType`, top-level `execservice`, `ports`, `env`, `globalenv`, `commandline`, `healthcheck`, and `depend_on`.
- Updates verifier guardrails so schema drift is caught locally.
- Removes leftover donor wording from README/package metadata.

## Verification
- `npm test`
  - packages the current OS archive
  - extracts it
  - starts the packaged wrapper
  - verifies HTTP `/` returns expected `404`
- `node --check scripts/package.mjs scripts/verify.mjs`
- `git diff --check`

## Residual Risk
- Existing inherited Total.js npm audit findings are still printed during package install. They are not changed by this schema-compatibility fix.

## Related
- Unblocks service-lasso/lasso-websight-cms#2 live-stack validation.