### PR TITLE
Migrate manifest to healthchecks contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The release pipeline packages the app with production `npm` dependencies already
 - Service id: `totaljs-messageservice`
 - Runtime dependency: `@node`
 - Default port: `8112`
-- Healthcheck: `GET /` must return `404`
+- Healthchecks: `http-root-ready` runs `GET /` and expects `404`
 - Global environment exported to dependants:
   - `MESSAGESERVICE_URL=http://127.0.0.1:${SERVICE_PORT}`
   - `MESSAGESERVICE_PORT=${SERVICE_PORT}`

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -12,6 +12,7 @@ const targetPlatform = process.env.TARGET_PLATFORM ?? process.platform;
 const verifyPort = Number(process.env.VERIFY_PORT ?? 18112);
 
 const serviceManifest = JSON.parse(await readFile(path.join(repoRoot, "service.json"), "utf8"));
+const serviceHealthchecks = serviceManifest.healthchecks;
 if (
   serviceManifest.id !== "totaljs-messageservice" ||
   serviceManifest.execservice !== "@node" ||
@@ -19,8 +20,13 @@ if (
   serviceManifest.artifact.platforms?.[targetPlatform]?.assetName !== archiveName(targetPlatform) ||
   serviceManifest.artifact.platforms?.[targetPlatform]?.archiveType !== (targetPlatform === "win32" ? "zip" : "tar.gz") ||
   serviceManifest.ports?.service !== 8112 ||
-  serviceManifest.healthcheck?.type !== "http" ||
-  serviceManifest.healthcheck?.expected_status !== 404 ||
+  "healthcheck" in serviceManifest ||
+  !Array.isArray(serviceHealthchecks) ||
+  serviceHealthchecks.length !== 1 ||
+  serviceHealthchecks[0]?.id !== "http-root-ready" ||
+  serviceHealthchecks[0]?.type !== "http" ||
+  serviceHealthchecks[0]?.url !== "http://127.0.0.1:${SERVICE_PORT}/" ||
+  serviceHealthchecks[0]?.expected_status !== 404 ||
   !serviceManifest.depend_on?.includes("@node")
 ) {
   throw new Error(`Total.js Message Service manifest drifted from current Service Lasso schema: ${JSON.stringify(serviceManifest)}`);
@@ -91,7 +97,7 @@ async function waitForHealth(url, expectedStatus) {
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
-  throw lastError ?? new Error("healthcheck timed out");
+  throw lastError ?? new Error("healthchecks[] readiness timed out");
 }
 
 const archivePath = await packageMessageService(targetPlatform, serviceVersion);
@@ -116,7 +122,7 @@ const child = spawn(process.execPath, [path.join(extractRoot, "lasso-totaljs-mes
 
 try {
   await waitForHealth(`http://127.0.0.1:${verifyPort}/`, 404);
-  console.log(`[lasso-totaljs-messageservice] verified healthcheck on port ${verifyPort}`);
+  console.log(`[lasso-totaljs-messageservice] verified healthchecks[] on port ${verifyPort}`);
 } finally {
   child.kill("SIGTERM");
 }

--- a/service.json
+++ b/service.json
@@ -56,13 +56,16 @@
     "darwin": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs",
     "default": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-messageservice.mjs"
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${SERVICE_PORT}/",
-    "expected_status": 404,
-    "retries": 180,
-    "interval": 500
-  },
+  "healthchecks": [
+    {
+      "id": "http-root-ready",
+      "type": "http",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/",
+      "expected_status": 404,
+      "retries": 180,
+      "interval": 500
+    }
+  ],
   "depend_on": [
     "@node"
   ],


### PR DESCRIPTION
## Issue
Closes #4

## Summary
- Migrates service.json from singular healthcheck to canonical healthchecks[].
- Adds stable check id http-root-ready while preserving the existing GET / expects 404 readiness behavior.
- Updates the repo verifier and README contract wording for the new manifest shape.

## Scope
- In scope: manifest contract migration, repo verifier assertion, README service contract wording.
- Out of scope: Service Lasso core healthcheck evaluator changes.

## Spec / contract / fixture impact
- Updated: service.json, scripts/verify.mjs, README.md.
- Contract source: service-lasso/service-lasso healthchecks reference and implementation plan.

## Service Lasso invariant impact
- Invariant: readiness behavior remains HTTP GET / expecting 404 on ${SERVICE_PORT}.
- Preservation proof: 
pm test packages the service, starts the wrapper, and verifies the expected HTTP status.

## Validation
- PASS 
pm test - $logDir\issue-4-npm-test.log
- PASS g -n '"healthcheck"|tcphost|tcpport' - $logDir\issue-4-singular-healthcheck-scan.log (no manifest alias usage; verifier retains a regression guard against the legacy key)

## Approval trail
- Required: no
- Evidence: Focused manifest migration for the selected Ready issue.

## Cleanup
- Branch pushed from develop; post-merge cleanup will return local checkout to clean develop where possible.